### PR TITLE
Warn against changing the Team on all schemes

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -53,7 +53,7 @@ pod install
 Open the Xcode project: `open DolphiniOS.xcworkspace/` (Make sure to open the xcworkspace!)
 
 * Click the Project in the Navigator Pane and choose "Signing & Capabilities" for the DolphiniOS target
-* Change the Team to your Developer ID
+* Change the Team to your Developer ID (Only change the Team to the scheme you want to avoid running out of App IDs on free accounts)
 * Edit the Scheme (or create a new one), and choose the build configuration (JB/Non-JB) you want for building/archiving 
 
 🚀 Build and Run! 


### PR DESCRIPTION
This will cause it so you can't sign any other apps or sideload anything else with the amount of different schemes on this. Best to put a warning, because I accidently signed the wrong one and was down an ID.