### PR TITLE
EmulationVC.mm controller.extendedGamepad->microGamepad

### DIFF
--- a/Source/iOS/DolphiniOS/DolphiniOS/UI/Emulation/EmulationViewController.mm
+++ b/Source/iOS/DolphiniOS/DolphiniOS/UI/Emulation/EmulationViewController.mm
@@ -100,7 +100,7 @@
         }
         else if (controller.microGamepad != nil)
         {
-          controller.extendedGamepad.buttonMenu.pressedChangedHandler = handler;
+          controller.microGamepad.buttonMenu.pressedChangedHandler = handler;
         }
       }
       else


### PR DESCRIPTION
Browsing through the code I spotted what may be a mistake on this line.

I doubt it's really used but why not.